### PR TITLE
Fix: Uncaught TypeError

### DIFF
--- a/src/ShopifyObject.php
+++ b/src/ShopifyObject.php
@@ -18,7 +18,7 @@ class ShopifyObject
     protected function get($id, $prefix = '')
     {
         $resource = $prefix . static::PLURAL . DIRECTORY_SEPARATOR . $id;
-        return $this->client->call("GET", $resource, null, null);
+        return $this->client->call("GET", $resource, null, []);
     }
 
     protected function getList(array $options = [], $prefix = '')
@@ -36,12 +36,12 @@ class ShopifyObject
     protected function delete($id, $prefix = '')
     {
         $resource = $prefix . static::PLURAL . DIRECTORY_SEPARATOR . $id;
-        return $this->client->call("DELETE", $resource, null, null);
+        return $this->client->call("DELETE", $resource, null, []);
     }
 
     protected function put($id, $data, $prefix = '')
     {
         $resource = $prefix . static::PLURAL . DIRECTORY_SEPARATOR . $id;
-        return $this->client->call("PUT", $resource, [static::SINGULAR => $data], null);
+        return $this->client->call("PUT", $resource, [static::SINGULAR => $data], []);
     }
 }

--- a/test/ShopifyFulfillmentEventTest.php
+++ b/test/ShopifyFulfillmentEventTest.php
@@ -37,7 +37,7 @@ class ShopifyFulfillmentEventTest extends \PHPUnit_Framework_TestCase
     {
         $this->mockClient->expects($this->once())
             ->method('call')
-            ->with('DELETE', 'orders/123/fulfillments/456/events/678', null, null);
+            ->with('DELETE', 'orders/123/fulfillments/456/events/678', null, []);
         $this->mockClient->fulfillment_events->destroy(678, 123, 456);
     }
 
@@ -45,7 +45,7 @@ class ShopifyFulfillmentEventTest extends \PHPUnit_Framework_TestCase
     {
         $this->mockClient->expects($this->once())
             ->method('call')
-            ->with('GET', 'orders/123/fulfillments/456/events/678', null, null);
+            ->with('GET', 'orders/123/fulfillments/456/events/678', null, []);
         $this->mockClient->fulfillment_events->read(678, 123, 456);
     }
 }

--- a/test/ShopifyFulfillmentTest.php
+++ b/test/ShopifyFulfillmentTest.php
@@ -21,7 +21,7 @@ class ShopifyFulfillmentTest extends \PHPUnit_Framework_TestCase
     {
         $this->mockClient->expects($this->once())
             ->method('call')
-            ->with('GET', 'orders/123/fulfillments/456', null, null);
+            ->with('GET', 'orders/123/fulfillments/456', null, []);
         $this->mockClient->fulfillments->read(456, 123);
     }
 
@@ -53,7 +53,7 @@ class ShopifyFulfillmentTest extends \PHPUnit_Framework_TestCase
     {
         $this->mockClient->expects($this->once())
             ->method('call')
-            ->with('PUT', 'orders/123/fulfillments/456', ['fulfillment' => ['tracking_number' => 'abc']], null);
+            ->with('PUT', 'orders/123/fulfillments/456', ['fulfillment' => ['tracking_number' => 'abc']], []);
         $this->mockClient->fulfillments->update(456, 123, ['tracking_number' => 'abc']);
     }
 }


### PR DESCRIPTION
Hi,

was using the php library to fetch single objects from the Shopify Api and received php fatals with the message:
`Fatal error: Uncaught TypeError: Argument 5 passed to Shopify\CurlRequest::request() must be of the type array, null given`.

This pull-request fixes the issue.

Running PHP: 7.1.4

