### PR TITLE
Make ShopifyClient more DI friendly

### DIFF
--- a/src/ShopifyClient.php
+++ b/src/ShopifyClient.php
@@ -22,14 +22,18 @@ class ShopifyClient
         "variant"
     ];
 
-    public function __construct($accessToken, $shopName)
+    public function __construct($accessToken = null, $shopName = null)
     {
         foreach (self::$resources as $resource) {
             $className = 'Shopify\Shopify' . str_replace("_", "", ucwords($resource, "_"));
             $this->{$resource . "s"} = new $className($this);
         }
-        $this->setAccessToken($accessToken);
-        $this->setShopName($shopName);
+        if ($accessToken !== null) {
+            $this->setAccessToken($accessToken);
+        }
+        if ($shopName !== null) {
+            $this->setShopName($shopName);
+        }
         $this->setHttpClient();
     }
 
@@ -66,6 +70,9 @@ class ShopifyClient
 
     private function authHeaders()
     {
+        if ($this->accessToken === null) {
+            throw new \LogicException('Access Token not set');
+        }
         return [
             'Content-Type: application/json',
             'X-Shopify-Access-Token: ' . $this->accessToken
@@ -74,6 +81,12 @@ class ShopifyClient
 
     public function call($method, $resource, $payload = null, $parameters = [])
     {
+        if ($this->shopName === null) {
+            throw new \LogicException('Shop name not set');
+        }
+        if ($this->shopName === null) {
+            throw new \LogicException('Shop name not set');
+        }
         if (!in_array($method, ["POST", "PUT", "PATCH", "GET", "DELETE", "HEAD"], true)) {
             throw new \InvalidArgumentException("Method not valid");
         }


### PR DESCRIPTION
#### Problem

if you wanna inject the dependency of `ShopifyClient` into some class from a DI container and you need to set `$accessToken` and a `$shopName` dynamically according to situations, you will want to set them after instantiation, but it's not easy because `ShopifyClient` first requires them as constructor arguments.

#### Approach
Stop requiring those constructor arguments and add some guard to avoid forgetting to set `$accessToken` and `$shopName` while allowing constructor arguments as it is.


```php
<?php

use Shopify\ShopifyClient;

class SomeClass
{
    private $client;

    public function __construct(ShopifyClient $client)
    {
        $this->client = $cilent; 
    }

    public doSomething($shop)
    {
        $this->client->setAccessToken($shop->getAccessToken());
        $this->client->setShopName($shop->getShopName())
        $products = $this->client->products->readList();
        // ...
    }
}
```

By the way, the class above can be tested like below for instance:

```php
<?php

use Mockery;
use PHPUnit\Framework\TestCase;
use Shopify\ShopifyClient;
use Shopify\ShopifyProduct;

class SomeClassTest extends TestCase
{
    public function testDoSomething()
    {
        $mockProduct = Mockery::mock(ShopifyProduct::class);
        $mockProduct->shouldReceive('readList')->andReturn(/* some prepared response */);

        $mockClient = Mockery::mock(ShopifyClient::class);
        $mockClient->shouldReceive('setAccessToken');
        $mockClient->shouldReceive('setShopName');
        $mockClient->products = $mockProduct;

        $someClass = new SomeClass($mockClient);
        $someClass->doSomething($shop);

        // ...
    }
}
```
@rodolfobandeira @joshubrown Hope this change make sense. 😃 